### PR TITLE
Enhance mobile UI and add controls

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>MangiaFortissimo</title>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="style.css">
@@ -16,6 +17,19 @@
         <input type="number" id="targetProtein" class="target-input" placeholder="Target Protein (g)" min="0">
         <input type="number" id="targetFiber" class="target-input" placeholder="Target Fiber (g)" min="0">
     </div>
+
+    <select id="categorySelect" class="category-select">
+        <option value="all" selected>All 🍎</option>
+        <option value="fruits">Fruits 🍓</option>
+        <option value="vegetables">Vegetables 🥦</option>
+        <option value="dairy">Dairy 🥛</option>
+        <option value="grains">Grains 🌾</option>
+        <option value="protein">Protein 🥩</option>
+        <option value="supplements">Supplements 💊</option>
+        <option value="others">Others 🍕</option>
+        <option value="recipe">Recipe 🍽️</option>
+        <option value="custom">Custom Recipes ✨</option>
+    </select>
 
     <div class="toggle-buttons">
         <button class="toggle-button active" data-category="all">All 🍎</button>
@@ -33,6 +47,7 @@
     <div id="foodButtons"></div>
     <div id="selectedFoods"></div>
     <button id="createRecipeBtn" class="create-recipe-btn">Create Custom Recipe</button>
+    <button id="clearAllBtn" class="clear-all-btn">Clear All</button>
 
     <div class="dashboard">
         <!-- Macronutrient Progress Circles -->

--- a/javascript.js
+++ b/javascript.js
@@ -28,6 +28,8 @@
     const buttonContainer = document.getElementById('foodButtons');
     const selectedFoodsContainer = document.getElementById('selectedFoods');
     const toggleButtons = document.querySelectorAll('.toggle-button');
+    const categorySelect = document.getElementById('categorySelect');
+    const clearAllBtn = document.getElementById('clearAllBtn');
 
     let selectedFoods = new Set();
 
@@ -59,26 +61,45 @@
         buttonContainer.appendChild(button);
     }
 
-        toggleButtons.forEach(button => {
+    function filterFoodButtons(category) {
+        const foodButtons = document.querySelectorAll('.food-button');
+        foodButtons.forEach(foodButton => {
+            const foodCategory = foodButton.dataset.category;
+            if (
+                category === 'all' ||
+                (category === 'custom' && foodCategory === 'custom') ||
+                (category !== 'custom' && foodCategory === category)
+            ) {
+                foodButton.style.display = 'inline-block';
+            } else {
+                foodButton.style.display = 'none';
+            }
+        });
+    }
+
+    toggleButtons.forEach(button => {
         button.addEventListener('click', () => {
             const category = button.dataset.category;
             toggleButtons.forEach(btn => btn.classList.remove('active'));
             button.classList.add('active');
-
-            const foodButtons = document.querySelectorAll('.food-button');
-            foodButtons.forEach(foodButton => {
-                const foodCategory = foodButton.dataset.category;
-                if (category === 'all' || 
-                    (category === 'custom' && foodCategory === 'custom') || 
-                    (category !== 'custom' && foodCategory === category)) {
-                    foodButton.style.display = 'inline-block';
-                } else {
-                    foodButton.style.display = 'none';
-                }
-            });
+            if (categorySelect) {
+                categorySelect.value = category;
+            }
+            filterFoodButtons(category);
             updateNutritionTable();
         });
+    });
+
+    if (categorySelect) {
+        categorySelect.addEventListener('change', () => {
+            const category = categorySelect.value;
+            toggleButtons.forEach(btn => {
+                btn.classList.toggle('active', btn.dataset.category === category);
+            });
+            filterFoodButtons(category);
+            updateNutritionTable();
         });
+    }
 function toggleFood(food, button) {
     if (selectedFoods.has(food)) {
         selectedFoods.delete(food);
@@ -171,6 +192,10 @@ function addSlider(food, isCustomRecipe = false, initialValue = null) {
     removeBtn.addEventListener('click', () => {
         selectedFoods.delete(foodName);
         div.remove();
+        const foodButton = document.querySelector(`.food-button[data-food="${foodName}"]`);
+        if (foodButton) {
+            foodButton.classList.remove('active');
+        }
         updateNutritionTable();
     });
 
@@ -180,12 +205,17 @@ function addSlider(food, isCustomRecipe = false, initialValue = null) {
     });
 }
 
-    function removeSlider(food) {
-            const slider = document.getElementById(`${sanitizeID(food)}-slider`);
+function removeSlider(food) {
+    const slider = document.getElementById(`${sanitizeID(food)}-slider`);
     if (slider) {
         slider.parentElement.parentElement.remove();
-            }
-        }
+    }
+    const foodButton = document.querySelector(`.food-button[data-food="${food}"]`);
+    if (foodButton) {
+        foodButton.classList.remove('active');
+    }
+    selectedFoods.delete(food);
+}
 
 function updateNutritionTable() {
     if (selectedFoods.size === 0) {
@@ -490,6 +520,15 @@ function updateMacroCircles(totals, targetCalories, targetProtein, targetFiber) 
 
 // Custom Recipe Creation
 const createRecipeBtn = document.getElementById('createRecipeBtn');
+
+if (clearAllBtn) {
+    clearAllBtn.addEventListener('click', () => {
+        selectedFoods.forEach(food => removeSlider(food));
+        selectedFoods.clear();
+        selectedFoodsContainer.innerHTML = '';
+        updateNutritionTable();
+    });
+}
 
 createRecipeBtn.addEventListener('click', () => {
     const flaggedFoodItems = document.querySelectorAll('.food-item.flagged-for-recipe');

--- a/style.css
+++ b/style.css
@@ -67,6 +67,17 @@ h2 {
     color: white;
 }
 
+.category-select {
+    display: none;
+    width: 100%;
+    padding: 10px 15px;
+    border: none;
+    border-radius: 20px;
+    background-color: #f0f0f0;
+    margin-bottom: 15px;
+    font-size: 16px;
+}
+
 /* Food Buttons */
 #foodButtons {
     display: flex;
@@ -405,6 +416,24 @@ footer a:hover {
     display: block;
 }
 
+.clear-all-btn {
+    padding: 10px 15px;
+    background-color: #f0f0f0;
+    border: none;
+    border-radius: 20px;
+    cursor: pointer;
+    transition: background-color 0.3s;
+    white-space: nowrap;
+    flex-shrink: 0;
+    margin: 10px auto 20px;
+    display: block;
+}
+
+.clear-all-btn:hover {
+    background-color: #e74c3c;
+    color: white;
+}
+
 .create-recipe-btn:hover {
     background-color: #3498db;
     color: white;
@@ -438,8 +467,11 @@ footer a:hover {
     }
 
     .toggle-buttons {
-        flex-wrap: wrap;
-        justify-content: flex-start;
+        display: none;
+    }
+
+    .category-select {
+        display: block;
     }
 
     .toggle-button {


### PR DESCRIPTION
## Summary
- add viewport meta for responsive scaling
- replace category bar with dropdown on small screens
- add clear-all button and synced category select
- remove button states when removing items
- hide toggle buttons on mobile and update CSS

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684d31e4bad0832084878c0b5263c9d7